### PR TITLE
fix: use repository signature instead of base repository

### DIFF
--- a/server/infra/database/PgMigrationRepositories.js
+++ b/server/infra/database/PgMigrationRepositories.js
@@ -32,7 +32,7 @@ class LegacyTreeAttributeRepository extends BaseRepository {
     }
 
     async add(tree_attributes) {
-        tree_attributes.forEach(attribute => {
+        await tree_attributes.forEach(attribute => {
             super.create(attribute);
         });
     }

--- a/server/infra/database/PgRepositories.js
+++ b/server/infra/database/PgRepositories.js
@@ -32,6 +32,10 @@ class CaptureRepository extends BaseRepository {
         .limit(options.limit)
         .offset(options.offset);
     }
+
+    async add(capture) {
+        return await super.create(capture);
+    }
 }
 
 class EventRepository extends BaseRepository {
@@ -39,6 +43,10 @@ class EventRepository extends BaseRepository {
         super("domain_event", session);
         this._tableName = "domain_event";
         this._session = session;
+    }
+
+    async add(domainEvent) {
+        return await super.create(domainEvent);
     }
 }
 

--- a/server/models/Repository.js
+++ b/server/models/Repository.js
@@ -5,7 +5,7 @@ class Repository {
     }
 
     async add(data) {
-        return await this.repoImpl.create(data);
+        return await this.repoImpl.add(data);
     }
 
     async update(data) {


### PR DESCRIPTION
Instead of making the model.Repository know the existence of BaseRepository, strictly adhere to the signature `add` and `update` to be invoked on the passed in repository implementation. This ensures the implementation in repository implementations such as classes found in PgRepositories are not by-passed, especially when there is some processing involved.