### PR TITLE
fix: update the capture_taken_at migrations

### DIFF
--- a/database/migrations/20210513233959-updateCaptureTakenColumn.js
+++ b/database/migrations/20210513233959-updateCaptureTakenColumn.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210513233959-updateCaptureTakenColumn-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210513233959-updateCaptureTakenColumn-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/database/migrations/20210513234014-modifyCaptureTakenColumn.js
+++ b/database/migrations/20210513234014-modifyCaptureTakenColumn.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210513234014-modifyCaptureTakenColumn-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210513234014-modifyCaptureTakenColumn-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/database/migrations/sqls/20210513114937-addCaptureTakenColumn-down.sql
+++ b/database/migrations/sqls/20210513114937-addCaptureTakenColumn-down.sql
@@ -1,2 +1,2 @@
 /* Replace with your SQL commands */
-ALTER TABLE raw_captures DROP capture_taken_at;
+ALTER TABLE raw_capture DROP capture_taken_at;

--- a/database/migrations/sqls/20210513114937-addCaptureTakenColumn-up.sql
+++ b/database/migrations/sqls/20210513114937-addCaptureTakenColumn-up.sql
@@ -1,2 +1,2 @@
 /* Replace with your SQL commands */
-ALTER TABLE raw_capture ADD capture_taken_at timestamptz NOT NULL;
+ALTER TABLE raw_capture ADD capture_taken_at timestamptz;

--- a/database/migrations/sqls/20210513233959-updateCaptureTakenColumn-down.sql
+++ b/database/migrations/sqls/20210513233959-updateCaptureTakenColumn-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/database/migrations/sqls/20210513233959-updateCaptureTakenColumn-up.sql
+++ b/database/migrations/sqls/20210513233959-updateCaptureTakenColumn-up.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+UPDATE raw_capture SET capture_taken_at = created_at;

--- a/database/migrations/sqls/20210513234014-modifyCaptureTakenColumn-down.sql
+++ b/database/migrations/sqls/20210513234014-modifyCaptureTakenColumn-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/database/migrations/sqls/20210513234014-modifyCaptureTakenColumn-up.sql
+++ b/database/migrations/sqls/20210513234014-modifyCaptureTakenColumn-up.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+ALTER TABLE raw_capture ALTER COLUMN capture_taken_at SET NOT NULL;

--- a/server/infra/database/PgRepositories.js
+++ b/server/infra/database/PgRepositories.js
@@ -24,6 +24,7 @@ class RawCaptureRepository extends BaseRepository {
             'note',
             'attributes',
             'status',
+            'capture_taken_at',
             'created_at',
             'updated_at'
         )


### PR DESCRIPTION
1) I fixed a typographical error I made in the addColumn down migration SQL file, changing table name `raw_captures` to `raw capture`

2) I added migration files for altering the `raw capture` table to add the `capture_taken_at` column allowing null, for updating all `capture_taken_at` values to copy from their corresponding created_at values, and for altering the `capture_taken_at` column to not allow null values