### PR TITLE
cors mapping

### DIFF
--- a/deployment/overlays/development/kustomization.yaml
+++ b/deployment/overlays/development/kustomization.yaml
@@ -1,11 +1,12 @@
 patchesStrategicMerge:
-- rabbitmq-connection-sealed-secret.yaml
-- database-connection-sealed-secret.yaml
-- database-migration-connection-sealed-secret.yaml
+  - rabbitmq-connection-sealed-secret.yaml
+  - database-connection-sealed-secret.yaml
+  - database-migration-connection-sealed-secret.yaml
+  - mapping.yaml
 images:
-- name: greenstand/treetracker-field-data
-  newTag: 1.11.0
+  - name: greenstand/treetracker-field-data
+    newTag: 1.11.0
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base

--- a/deployment/overlays/test/kustomization.yaml
+++ b/deployment/overlays/test/kustomization.yaml
@@ -1,11 +1,12 @@
 patchesStrategicMerge:
-- rabbitmq-connection-sealed-secret.yaml
-- database-connection-sealed-secret.yaml
-- database-migration-connection-sealed-secret.yaml
+  - rabbitmq-connection-sealed-secret.yaml
+  - database-connection-sealed-secret.yaml
+  - database-migration-connection-sealed-secret.yaml
+  - mapping
 images:
-- name: greenstand/treetracker-field-data
-  newTag: 1.11.0
+  - name: greenstand/treetracker-field-data
+    newTag: 1.11.0
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base


### PR DESCRIPTION
- fix: lint
- chore(release): 1.9.0 [skip ci]
- chore: bump docker image tag 1.9.0 [skip ci]
- fix: add created_at column on wallet registration
- chore(release): 1.9.1 [skip ci]
- fix: trigger deployment
- chore(release): 1.9.2 [skip ci]
- chore: bump docker image tag 1.9.2 [skip ci]
- chore: bump docker image tag 1.9.2 [skip ci]
- chore: refactor handlers and routes
- fix: replay event endpoint
- fix: rabbitmq
- chore: update package.json
- fix: tests
- chore(release): 1.9.3 [skip ci]
- chore: bump docker image tag 1.9.3 [skip ci]
- fix: apply verification by id
- feat: add raw capture reject endpoint
- chore: remove only from test
- chore: fix tests
- chore(release): 1.10.0 [skip ci]
- chore: bump docker image tag 1.10.0 [skip ci]
- fix: make call to the legacy API
- chore: fix minor test issue
- chore(release): 1.10.1 [skip ci]
- chore: bump docker image tag 1.10.1 [skip ci]
- fix: legacy api url/ readme
- chore(release): 1.10.2 [skip ci]
- chore: bump docker image tag 1.10.2 [skip ci]
- fix: legacy API url
- chore(release): 1.10.3 [skip ci]
- chore: bump docker image tag 1.10.3 [skip ci]
- fix: add updated_at/schema
- chore(release): 1.10.4 [skip ci]
- chore: bump docker image tag 1.10.4 [skip ci]
- fix: add updated_at
- chore(release): 1.10.5 [skip ci]
- chore: bump docker image tag 1.10.5 [skip ci]
- fix: update rabbitmq implementation
- chore: fix tests
- chore: remove only
- chore: update docs
- fix: minor fix
- chore(release): 1.10.6 [skip ci]
- chore: bump docker image tag 1.10.6 [skip ci]
- chore: bump docker image tag 1.10.6 [skip ci]
- chore: bump docker image tag 1.10.6 [skip ci]
- chore: add seeds
- fix: add session start_time and re_tracking
- fix: add start-time to result
- chore(release): 1.10.7 [skip ci]
- chore: bump docker image tag 1.10.7 [skip ci]
- chore: update seeds
- chore: update seed
- fix: remove retracking
- chore(release): 1.10.8 [skip ci]
- chore: bump docker image tag 1.10.8 [skip ci]
- feat: added mapping for cors policy
- fix: add bulk pack version to session
- fix: semantic release
- chore(release): 1.11.0 [skip ci]
- chore: bump docker image tag 1.11.0 [skip ci]
- chore: bump docker image tag 1.11.0 [skip ci]
- chore: bump docker image tag 1.11.0 [skip ci]
- fix: cors mapping
